### PR TITLE
SSH User Config File support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ To unlock the target system (after initial setup; see below):
 2. Enter the password to your ssh key (if there is one).
 3. Enter the drive encryption password(s).
 
+For additional options and default file locations, run:
+
+   ```sh
+   unlock-cryptroot --help
+   ```
+   
 Tested on:
 * Ubuntu 16.04 (Xenial)
 * Ubuntu 15.10 (Wily)

--- a/unlock-cryptroot
+++ b/unlock-cryptroot
@@ -68,7 +68,8 @@ shell_quote() (
 # parse arguments
 knownhosts=~/.ssh/known_hosts.initramfs
 idbase=~/.ssh/id_rsa.initramfs_
-config=~/.ssh/config.initramfs
+configdefault=~/.ssh/config.initramfs
+unset config
 unset id
 runscript=true
 while [ "$#" -gt 0 ]; do
@@ -94,6 +95,18 @@ host=$1; shift
 [ -n "${id+set}" ] || id=${idbase}${host%%.*}
 [ -r "${id}" ] || fatal "can't read ssh key ${id}"
 
+if [ -z ${config+x} ]; then
+    if [ -r ${configdefault} ]; then
+	config=${configdefault}
+    fi
+else
+   [ -r "${config}" ] || fatal "can't read ssh user config file ${config}"
+fi
+if [ -z ${config+x} ]; then
+    unset sshconfigopt
+else
+    sshconfigopt="-F ${config}"
+fi
 
 script=$(cat <<\END_OF_SCRIPT
 #!/bin/sh
@@ -189,7 +202,7 @@ run_ssh() {
     case $1 in -t) forcetty=$1; shift;; esac
     ssh -o UserKnownHostsFile="${knownhosts}" \
         -i "${id}" \
-	-F "${config}" \
+	${sshconfigopt} \
         ${forcetty} \
         root@"${host}" "$@"
 }

--- a/unlock-cryptroot
+++ b/unlock-cryptroot
@@ -25,6 +25,10 @@ Arguments:
     Path to the 'known_hosts' file.
     Default: ${knownhosts}
 
+  -c <config_file>, --config <config_file>, --config=<config_file>
+    Path to the 'config' file.
+    Default: ${config}
+
   -l, --login
     Just log in, don't try to unlock the system.
 
@@ -64,6 +68,7 @@ shell_quote() (
 # parse arguments
 knownhosts=~/.ssh/known_hosts.initramfs
 idbase=~/.ssh/id_rsa.initramfs_
+config=~/.ssh/config.initramfs
 unset id
 runscript=true
 while [ "$#" -gt 0 ]; do
@@ -71,6 +76,7 @@ while [ "$#" -gt 0 ]; do
     case $1 in
         # convert "--opt=the value" to --opt "the value".
         --*'='*) shift; set -- "${arg%%=*}" "${arg#*=}" "$@"; continue;;
+	-c|--config) shift; config=$1;;
         -h|--help) usage; exit 0;;
         -i|--identity) shift; id=$1;;
         -k|--known-hosts) shift; knownhosts=$1;;
@@ -183,6 +189,7 @@ run_ssh() {
     case $1 in -t) forcetty=$1; shift;; esac
     ssh -o UserKnownHostsFile="${knownhosts}" \
         -i "${id}" \
+	-F "${config}" \
         ${forcetty} \
         root@"${host}" "$@"
 }


### PR DESCRIPTION
This pull request contains two changes: one that adds support for ssh's user config file via a -c/--config option, and another one that mentions the usage function in the README file for better discoverability.